### PR TITLE
1.40.1

### DIFF
--- a/Invoice Maker.xcodeproj/project.pbxproj
+++ b/Invoice Maker.xcodeproj/project.pbxproj
@@ -798,7 +798,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.40.0;
+				MARKETING_VERSION = 1.40.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "MN.Invoice-Maker";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -834,7 +834,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.40.0;
+				MARKETING_VERSION = 1.40.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "MN.Invoice-Maker";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Invoice Maker.xcodeproj/project.pbxproj
+++ b/Invoice Maker.xcodeproj/project.pbxproj
@@ -398,8 +398,8 @@
 		A6ACF59C2B7AC77800D4727B /* Product */ = {
 			isa = PBXGroup;
 			children = (
-				A6E205032DEB8C84009BEF4A /* SchemaV1+Product.swift */,
 				A6ACF59A2B7AB4DB00D4727B /* ProductDetailsV1.swift */,
+				A6E205032DEB8C84009BEF4A /* SchemaV1+Product.swift */,
 			);
 			path = Product;
 			sourceTree = "<group>";

--- a/Invoice Maker/Model/OldSchema/DataMigrationManager.swift
+++ b/Invoice Maker/Model/OldSchema/DataMigrationManager.swift
@@ -175,6 +175,7 @@ final class DataMigrationManager {
                 // Migrate invoice items
                 for oldItem in oldInvoice.items {
                     let newItem = InvoiceItem(
+                        productId: UUID(),
                         productCode: oldItem.productCode,
                         productName: oldItem.productName,
                         productPrice: oldItem.productPrice,

--- a/Invoice Maker/Model/SchemaV1/Invoice/Observables/InvoiceDetailsV1.swift
+++ b/Invoice Maker/Model/SchemaV1/Invoice/Observables/InvoiceDetailsV1.swift
@@ -96,7 +96,7 @@ class InvoiceDetailsV1 {
 
 extension InvoiceDetailsV1: Equatable {
     static func == (lhs: InvoiceDetailsV1, rhs: InvoiceDetailsV1) -> Bool {
-        let areItemsEqual: Bool = lhs.items.elementsEqual(rhs.items) { $0.productCode == $1.productCode && $0.quantity == $1.quantity }
+        let areItemsEqual: Bool = lhs.items.elementsEqual(rhs.items)
 
         return lhs.number == rhs.number &&
             lhs.type == rhs.type &&

--- a/Invoice Maker/Model/SchemaV1/Invoice/Observables/ItemDetailsV1.swift
+++ b/Invoice Maker/Model/SchemaV1/Invoice/Observables/ItemDetailsV1.swift
@@ -11,6 +11,7 @@ import SwiftData
 @Observable
 class ItemDetailsV1: Identifiable {
     var id: UUID = UUID()
+    var productId: UUID
     var productCode: Int
     var productName: String
     var productPrice: Decimal
@@ -18,7 +19,15 @@ class ItemDetailsV1: Identifiable {
     var productDetails: String?
     var quantity: Int
 
-    init(productCode: Int, productName: String, productPrice: Decimal, productCurrency: Currency, productDetails: String? = nil, quantity: Int = 1) {
+    init(productId: UUID,
+         productCode: Int,
+         productName: String,
+         productPrice: Decimal,
+         productCurrency: Currency,
+         productDetails: String? = nil,
+         quantity: Int = 1
+    ) {
+        self.productId = productId
         self.productCode = productCode
         self.productName = productName
         self.productPrice = productPrice
@@ -28,17 +37,20 @@ class ItemDetailsV1: Identifiable {
     }
 
     convenience init(from item: SchemaV1.InvoiceItem) {
-        self.init(productCode: item.productCode,
-                  productName: item.productName,
-                  productPrice: item.productPrice,
-                  productCurrency: item.productCurrency,
-                  productDetails: item.productDetails,
-                  quantity: item.quantity
+        self.init(
+            productId: item.productId,
+            productCode: item.productCode,
+            productName: item.productName,
+            productPrice: item.productPrice,
+            productCurrency: item.productCurrency,
+            productDetails: item.productDetails,
+            quantity: item.quantity
         )
     }
 
-    convenience init(from product: Product, quantity: Int) {
-        self.init(productCode: product.code,
+    convenience init(from product: SchemaV1.Product, quantity: Int) {
+        self.init(productId: product.id,
+                  productCode: product.code,
                   productName: product.name,
                   productPrice: product.price,
                   productCurrency: product.currency,
@@ -50,7 +62,8 @@ class ItemDetailsV1: Identifiable {
 
 extension ItemDetailsV1: Equatable {
     static func == (lhs: ItemDetailsV1, rhs: ItemDetailsV1) -> Bool {
-        lhs.productCode == rhs.productCode &&
+        lhs.productId == rhs.productId &&
+            lhs.productCode == rhs.productCode &&
             lhs.productName == rhs.productName &&
             lhs.productPrice == rhs.productPrice &&
             lhs.productCurrency == rhs.productCurrency &&
@@ -61,6 +74,7 @@ extension ItemDetailsV1: Equatable {
 
 extension ItemDetailsV1: Hashable {
     func hash(into hasher: inout Hasher) {
+        hasher.combine(productId)
         hasher.combine(productCode)
         hasher.combine(productName)
         hasher.combine(productPrice)

--- a/Invoice Maker/Model/SchemaV1/Invoice/SchemaV1+InvoiceItem.swift
+++ b/Invoice Maker/Model/SchemaV1/Invoice/SchemaV1+InvoiceItem.swift
@@ -11,6 +11,7 @@ import SwiftData
 extension SchemaV1 {
     @Model
     class InvoiceItem {
+        var productId: UUID
         var productCode: Int
         var productName: String
         var productPrice: Decimal
@@ -22,10 +23,11 @@ extension SchemaV1 {
         var total: Decimal { productPrice * Decimal(quantity) }
 
         var product: SchemaV1.Product {
-            Product(code: productCode, name: productName, price: productPrice, currency: productCurrency, details: productDetails)
+            Product(id: productId, code: productCode, name: productName, price: productPrice, currency: productCurrency, details: productDetails)
         }
 
-        init(productCode: Int,
+        init(productId: UUID,
+             productCode: Int,
              productName: String,
              productPrice: Decimal,
              productCurrency: Currency,
@@ -33,6 +35,7 @@ extension SchemaV1 {
              quantity: Int = 1,
              invoice: SchemaV1.Invoice? = nil
         ) {
+            self.productId = productId
             self.productCode = productCode
             self.productName = productName
             self.productPrice = productPrice
@@ -43,17 +46,8 @@ extension SchemaV1 {
         }
 
         convenience init(from item: ItemDetailsV1) {
-            self.init(productCode: item.productCode,
-                      productName: item.productName,
-                      productPrice: item.productPrice,
-                      productCurrency: item.productCurrency,
-                      productDetails: item.productDetails,
-                      quantity: item.quantity
-            )
-        }
-
-        convenience init(from item: SchemaV1.InvoiceItem) {
-            self.init(productCode: item.productCode,
+            self.init(productId: item.productId,
+                      productCode: item.productCode,
                       productName: item.productName,
                       productPrice: item.productPrice,
                       productCurrency: item.productCurrency,

--- a/Invoice Maker/Model/SchemaV1/Product/SchemaV1+Product.swift
+++ b/Invoice Maker/Model/SchemaV1/Product/SchemaV1+Product.swift
@@ -10,7 +10,8 @@ import SwiftData
 
 extension SchemaV1 {
     @Model
-    class Product {
+    class Product: Identifiable {
+        var id: UUID
         @Attribute(.unique) var code: Int
         var name: String
         var price: Decimal
@@ -18,7 +19,8 @@ extension SchemaV1 {
         var details: String?
         var createdDate: Date = Date.now
 
-        init(code: Int, name: String, price: Decimal, currency: Currency, details: String?) {
+        init(id: UUID = UUID(), code: Int, name: String, price: Decimal, currency: Currency, details: String?) {
+            self.id = id
             self.code = code
             self.name = name
             self.price = price
@@ -49,7 +51,8 @@ extension SchemaV1.Product {
 
 extension SchemaV1.Product: Equatable {
     static func == (lhs: SchemaV1.Product, rhs: SchemaV1.Product) -> Bool {
-        lhs.code == rhs.code &&
+        lhs.id == rhs.id &&
+            lhs.code == rhs.code &&
             lhs.name == rhs.name &&
             lhs.price == rhs.price &&
             lhs.currency == rhs.currency &&
@@ -59,6 +62,6 @@ extension SchemaV1.Product: Equatable {
 
 extension SchemaV1.Product: Hashable {
     func hash(into hasher: inout Hasher) {
-        hasher.combine(code)
+        hasher.combine(id)
     }
 }

--- a/Invoice Maker/Views/Invoices/Invoice/InvoiceForm/InvoiceFormView.swift
+++ b/Invoice Maker/Views/Invoices/Invoice/InvoiceForm/InvoiceFormView.swift
@@ -202,7 +202,7 @@ struct InvoiceFormView: View {
             invoice.update(with: invoiceDetails)
 
             invoiceDetails.items.forEach { item in
-                if let existingItem = invoice.items.first(where: { $0.productCode == item.productCode }) {
+                if let existingItem = invoice.items.first(where: { $0.productId == item.productId }) {
                     existingItem.update(with: item)
                 } else {
                     let item = InvoiceItem(from: item)
@@ -211,7 +211,7 @@ struct InvoiceFormView: View {
             }
 
             invoice.items.forEach { item in
-                if (!invoiceDetails.items.contains { $0.productCode == item.productCode }) {
+                if (!invoiceDetails.items.contains { $0.productId == item.productId }) {
                     modelContext.delete(item)
                 }
             }

--- a/Invoice Maker/Views/Invoices/Invoice/InvoiceForm/InvoiceProductSelection.swift
+++ b/Invoice Maker/Views/Invoices/Invoice/InvoiceForm/InvoiceProductSelection.swift
@@ -51,8 +51,8 @@ struct InvoiceProductSelection: View {
             .environment(\.editMode, .constant(.active))
         }
         .onAppear {
-            let itemProductCodes = Set(items.map { $0.productCode })
-            selectedProducts = Set(products.filter { itemProductCodes.contains($0.code) })
+            let itemProductIds = Set(items.map { $0.productId })
+            selectedProducts = Set(products.filter { itemProductIds.contains($0.id) })
         }
         .sheet(isPresented: $showProductFormView) {
             NavigationStack {
@@ -62,10 +62,10 @@ struct InvoiceProductSelection: View {
     }
 
     func updateItems(with selectedProducts: Set<Product>) {
-        let itemProductCodes = Set(items.map { $0.productCode })
+        let itemProductIds = Set(items.map { $0.productId })
 
         selectedProducts.forEach { product in
-            if !itemProductCodes.contains(product.code) {
+            if !itemProductIds.contains(product.id) {
                 let item = ItemDetails(from: product, quantity: 1)
 
                 items.append(item)
@@ -73,7 +73,7 @@ struct InvoiceProductSelection: View {
         }
 
         items = items.filter { item in
-            selectedProducts.contains(where: { $0.code == item.productCode })
+            selectedProducts.contains(where: { $0.id == item.productId })
         }
     }
 }

--- a/Invoice Maker/Views/Products/Product/ProductDetailView.swift
+++ b/Invoice Maker/Views/Products/Product/ProductDetailView.swift
@@ -19,10 +19,8 @@ struct ProductDetailView: View {
         self.product = product
         _isEditing = isEditing
 
-        let productCode = product.code
-        let predicate = #Predicate<InvoiceN> {
-            $0.items.contains { $0.productCode == productCode }
-        }
+        let productId = product.id
+        let predicate = #Predicate<InvoiceN> { $0.items.contains { $0.productId == productId } }
 
         _invoices = Query(filter: predicate, sort: \.createdDate, order: .reverse)
     }


### PR DESCRIPTION
This pull request updates the product identification system throughout the invoice and product models, shifting from using product codes to using unique product IDs (`UUID`). This change ensures more robust and reliable associations between products and invoice items, and updates all relevant model initializers, equality/hash logic, and UI logic to work with product IDs. Additionally, the pull request refactors related view logic and data migration to support this new approach.

**Model and Data Structure Updates:**

* Added a `productId: UUID` property to `SchemaV1.Product`, `SchemaV1.InvoiceItem`, and `ItemDetailsV1`, and updated their initializers, equality, and hash methods to use `id`/`productId` for identification. (`Invoice Maker/Model/SchemaV1/Product/SchemaV1+Product.swift` [[1]](diffhunk://#diff-6439cca6c027cb7466fc94bd339b1fed57f00cf7285685e4d4b56c69fff2fa0fL13-R23) [[2]](diffhunk://#diff-6439cca6c027cb7466fc94bd339b1fed57f00cf7285685e4d4b56c69fff2fa0fR54) [[3]](diffhunk://#diff-6439cca6c027cb7466fc94bd339b1fed57f00cf7285685e4d4b56c69fff2fa0fL62-R65); `Invoice Maker/Model/SchemaV1/Invoice/SchemaV1+InvoiceItem.swift` [[4]](diffhunk://#diff-4000e4a72f97835f0835abf4580961846b4c435940a63b1cf06ae61cb0645610R14) [[5]](diffhunk://#diff-4000e4a72f97835f0835abf4580961846b4c435940a63b1cf06ae61cb0645610L25-R38) [[6]](diffhunk://#diff-4000e4a72f97835f0835abf4580961846b4c435940a63b1cf06ae61cb0645610L46-R50); `Invoice Maker/Model/SchemaV1/Invoice/Observables/ItemDetailsV1.swift` [[7]](diffhunk://#diff-9ca1de3a5c43d6dd46f29806d6aacaca3bbc3912669c02ca8fce61cf924b089aR14-R30) [[8]](diffhunk://#diff-9ca1de3a5c43d6dd46f29806d6aacaca3bbc3912669c02ca8fce61cf924b089aL31-R42) [[9]](diffhunk://#diff-9ca1de3a5c43d6dd46f29806d6aacaca3bbc3912669c02ca8fce61cf924b089aL40-R53) [[10]](diffhunk://#diff-9ca1de3a5c43d6dd46f29806d6aacaca3bbc3912669c02ca8fce61cf924b089aR65) [[11]](diffhunk://#diff-9ca1de3a5c43d6dd46f29806d6aacaca3bbc3912669c02ca8fce61cf924b089aR77)

* Updated the data migration logic to assign a new `UUID` as `productId` for migrated invoice items. (`Invoice Maker/Model/OldSchema/DataMigrationManager.swift` [Invoice Maker/Model/OldSchema/DataMigrationManager.swiftR178](diffhunk://#diff-bb95da31e92e858903c064942620defeef8b5810871015e30af31841d624fb8fR178))

**View and UI Logic Refactoring:**

* Updated all view logic to use `productId` for matching and updating products and invoice items, replacing previous reliance on `productCode`. This includes selection, update, and filtering logic in invoice and product views. (`Invoice Maker/Views/Invoices/Invoice/InvoiceDetails/InvoiceDetailView.swift` [[1]](diffhunk://#diff-7967b5ee69105549b97d603687a5a2effca26d17e17fdbced9b52db9412e578aL62-R65) [[2]](diffhunk://#diff-7967b5ee69105549b97d603687a5a2effca26d17e17fdbced9b52db9412e578aL103-R105) [[3]](diffhunk://#diff-7967b5ee69105549b97d603687a5a2effca26d17e17fdbced9b52db9412e578aR114-R122); `Invoice Maker/Views/Invoices/Invoice/InvoiceForm/InvoiceFormView.swift` [[4]](diffhunk://#diff-10a1920818e6921497ffb25cd632ed079fd213312fa3d43a2c263986a29217d5L205-R205) [[5]](diffhunk://#diff-10a1920818e6921497ffb25cd632ed079fd213312fa3d43a2c263986a29217d5L214-R214); `Invoice Maker/Views/Invoices/Invoice/InvoiceForm/InvoiceProductSelection.swift` [[6]](diffhunk://#diff-cff6d2d854b4c68b3b5d46974da3bb38feef3d99914128cb0319f82527261850L54-R55) [[7]](diffhunk://#diff-cff6d2d854b4c68b3b5d46974da3bb38feef3d99914128cb0319f82527261850L65-R76); `Invoice Maker/Views/Products/Product/ProductDetailView.swift` [[8]](diffhunk://#diff-c9f6c8d6e4191c57293b0d96a828bdb5a3cef731b96d45ee72954c3706c15f0eL22-R23)

**Project Organization:**

* Minor adjustment to the file order in the Xcode project for `SchemaV1+Product.swift`. (`Invoice Maker.xcodeproj/project.pbxproj` [Invoice Maker.xcodeproj/project.pbxprojL401-R402](diffhunk://#diff-8970c4e501c1dcbcbb9b8a2bb5b7a9bf3b65c740bac79b13d6e7eed18ff7caf0L401-R402))