### PR TITLE
Reorder and add invoice summary fields

### DIFF
--- a/Invoice Maker/Views/Invoices/Invoice/InvoiceDetails/InvoiceMainDetailsView.swift
+++ b/Invoice Maker/Views/Invoices/Invoice/InvoiceDetails/InvoiceMainDetailsView.swift
@@ -14,14 +14,15 @@ struct InvoiceMainDetailsView: View {
         Section {
             LabeledContent("شماره فاکتور", value: invoice.number)
             LabeledContent("نوع فاکتور", value: invoice.type.label)
-            LabeledContent("جمع کل", value: invoice.total, format: .currencyFormatter(code: invoice.currency))
             LabeledContent("نوع ارز", value: invoice.currency.label)
             LabeledContent("تاریخ صدور", value: invoice.date, format: .dateTime)
             if invoice.options.contains(.dueDate) {
                 LabeledContent("تاریخ سررسید", value: invoice.dueDate, format: .dateTime)
             }
+            LabeledContent("جمع کل", value: invoice.total, format: .currencyFormatter(code: invoice.currency))
             LabeledContent("تخفیف (٪)", value: invoice.discount, format: .number)
             LabeledContent("ارزش افزوده (٪)", value: invoice.vat, format: .number)
+            LabeledContent("مبلغ نهایی", value: invoice.totalWithVAT, format: .currencyFormatter(code: invoice.currency))
             LabeledContent("توضیحات", value: invoice.note.isEmpty ? "-" : invoice.note)
         }
     }


### PR DESCRIPTION
Moved the 'جمع کل' (total) field below currency and date fields, and added a new 'مبلغ نهایی' (final amount) field displaying invoice.totalWithVAT with currency formatting. This improves the clarity and completeness of invoice details.