### PR TITLE
1.41.3

### DIFF
--- a/Invoice Maker.xcodeproj/project.pbxproj
+++ b/Invoice Maker.xcodeproj/project.pbxproj
@@ -845,7 +845,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.41.2;
+				MARKETING_VERSION = 1.41.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "MN.Invoice-Maker";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -884,7 +884,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.41.2;
+				MARKETING_VERSION = 1.41.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "MN.Invoice-Maker";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Invoice Maker/Model/Currency/CurrencyFormatter.swift
+++ b/Invoice Maker/Model/Currency/CurrencyFormatter.swift
@@ -11,22 +11,27 @@ struct CurrencyFormatStyle: FormatStyle {
     var currency: Currency
 
     func format(_ value: Decimal) -> String {
+        let formatter = NumberFormatter()
+        formatter.maximumFractionDigits = 3
+        formatter.minimumFractionDigits = 0
+        formatter.decimalSeparator = "."
+        formatter.groupingSeparator = ","
+        formatter.locale = Locale(identifier: "fa")
+
         switch currency {
         case .IRR_Toman:
-            let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
-            formatter.maximumFractionDigits = 0
-            formatter.groupingSeparator = ","
-            formatter.locale = Locale(identifier: "fa")
             let formatted = formatter.string(from: NSDecimalNumber(decimal: value)) ?? "0"
             return "تومان \(formatted)"
-        default:
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .currency
-            formatter.currencyCode = currency.rawValue
-            formatter.locale = Locale(identifier: "fa")
+        case .IRR:
+            formatter.numberStyle = .decimal
             let formatted = formatter.string(from: NSDecimalNumber(decimal: value)) ?? "0"
-            return formatted
+            return "ریال \(formatted)"
+//        default:
+//            formatter.numberStyle = .currency
+//            formatter.currencyCode = currency.rawValue
+//            let formatted = formatter.string(from: NSDecimalNumber(decimal: value)) ?? "0"
+//            return formatted
         }
     }
 }

--- a/Invoice Maker/Model/PDF/PDF.swift
+++ b/Invoice Maker/Model/PDF/PDF.swift
@@ -173,22 +173,22 @@ struct PDF {
         table[rows: netTotalRow, columns: 1 ... 4].merge()
         table[netTotalRow, 1].style = headerStyle
 
-        let discountRow = netTotalRow + 1
-        table[discountRow, 0].content = try? PDFTableContent(content: "-\(formattedNumber(invoice.discountAmount))")
-        table[discountRow, 1].content = try? PDFTableContent(content: formattedNumber((invoice.discount ?? 0) * 100) + " %")
-        table[discountRow, 2].content = try? PDFTableContent(content: "تخفیف")
-        table[rows: discountRow, columns: 2 ... 4].merge()
-        table[discountRow, 2].style = headerStyle
-
-        let vatRow = discountRow + 1
+        let vatRow = netTotalRow + 1
         table[vatRow, 0].content = try? PDFTableContent(content: "+\(formattedNumber(invoice.vatAmount))")
         table[vatRow, 1].content = try? PDFTableContent(content: formattedNumber((invoice.vat ?? 0) * 100) + " %")
         table[vatRow, 2].content = try? PDFTableContent(content: "ارزش افزوده")
         table[rows: vatRow, columns: 2 ... 4].merge()
         table[vatRow, 2].style = headerStyle
 
-        let totalRow = vatRow + 1
-        table[totalRow, 0].content = try? PDFTableContent(content: "\(formattedNumber(invoice.totalWithVAT))")
+        let discountRow = vatRow + 1
+        table[discountRow, 0].content = try? PDFTableContent(content: "-\(formattedNumber(invoice.discountAmount))")
+        table[discountRow, 1].content = try? PDFTableContent(content: formattedNumber((invoice.discount ?? 0) * 100) + " %")
+        table[discountRow, 2].content = try? PDFTableContent(content: "تخفیف")
+        table[rows: discountRow, columns: 2 ... 4].merge()
+        table[discountRow, 2].style = headerStyle
+
+        let totalRow = discountRow + 1
+        table[totalRow, 0].content = try? PDFTableContent(content: "\(formattedNumber(invoice.totalWithDiscount))")
         table[totalRow, 1].content = try? PDFTableContent(content: "مبلغ نهایی (\(invoice.currency?.label ?? "-"))")
         table[rows: totalRow, columns: 1 ... 4].merge()
         table[totalRow, 0].style = PDFTableCellStyle(borders: PDFTableCellBorders(top: border, right: border), font: .systemFont(ofSize: 14, weight: .bold))

--- a/Invoice Maker/Model/SchemaV1/Invoice/SchemaV1+Invoice.swift
+++ b/Invoice Maker/Model/SchemaV1/Invoice/SchemaV1+Invoice.swift
@@ -37,20 +37,20 @@ extension SchemaV1 {
             return total
         }
 
-        var discountAmount: Decimal {
-            return (total * (discount ?? 0))
-        }
-
-        var totalWithDiscount: Decimal {
-            return (total - discountAmount)
-        }
-
         var vatAmount: Decimal {
-            return (totalWithDiscount * (vat ?? 0))
+            return (total * (vat ?? 0))
         }
 
         var totalWithVAT: Decimal {
-            return (totalWithDiscount + vatAmount)
+            return (total + vatAmount)
+        }
+
+        var discountAmount: Decimal {
+            return (totalWithVAT * (discount ?? 0))
+        }
+
+        var totalWithDiscount: Decimal {
+            return (totalWithVAT - discountAmount)
         }
 
         var getCustomer: SchemaV1.Customer? {

--- a/Invoice Maker/Views/Customers/CustomersView.swift
+++ b/Invoice Maker/Views/Customers/CustomersView.swift
@@ -95,10 +95,10 @@ struct CustomersView: View {
                 fetchContacts(with: identifiers)
             }
             .alert("دسترسی به مخاطبین", isPresented: $showContactsPermissionAlert) {
-                Button("ادامه") {
+                Button("بازگشت") {
                     showContactsPermissionAlert.toggle()
                 }
-                
+
                 Button("تنظیمات") {
                     if let url = URL(string: UIApplication.openSettingsURLString) {
                         if UIApplication.shared.canOpenURL(url) {

--- a/Invoice Maker/Views/Invoices/Invoice/InvoiceDetails/InvoiceMainDetailsView.swift
+++ b/Invoice Maker/Views/Invoices/Invoice/InvoiceDetails/InvoiceMainDetailsView.swift
@@ -26,9 +26,9 @@ struct InvoiceMainDetailsView: View {
                 LabeledContent("تاریخ سررسید", value: "-")
             }
             LabeledContent("جمع کل", value: invoice.total, format: .currencyFormatter(code: invoice.currency ?? Currency.IRR))
-            LabeledContent("تخفیف", value: invoice.discount ?? 0, format: .percent)
             LabeledContent("ارزش افزوده", value: invoice.vat ?? 0, format: .percent)
-            LabeledContent("مبلغ نهایی", value: invoice.totalWithVAT, format: .currencyFormatter(code: invoice.currency ?? Currency.IRR))
+            LabeledContent("تخفیف", value: invoice.discount ?? 0, format: .percent)
+            LabeledContent("مبلغ نهایی", value: invoice.totalWithDiscount, format: .currencyFormatter(code: invoice.currency ?? Currency.IRR))
             LabeledContent("توضیحات", value: invoice.note?.isEmpty == false ? invoice.note! : "-")
         }
     }

--- a/Invoice Maker/Views/Invoices/Invoice/InvoiceForm/InvoiceFormView.swift
+++ b/Invoice Maker/Views/Invoices/Invoice/InvoiceForm/InvoiceFormView.swift
@@ -61,9 +61,9 @@ struct InvoiceFormView: View {
                         DatePicker("تاریخ سررسید", selection: $invoiceDetails.dueDate)
                     }
 
-                    TextField("تخفیف (٪)", value: $invoiceDetails.discount, format: .percent)
-
                     TextField("ارزش افزوده (٪)", value: $invoiceDetails.vat, format: .percent)
+
+                    TextField("تخفیف (٪)", value: $invoiceDetails.discount, format: .percent)
                 }
 
                 Section {

--- a/Invoice Maker/Views/Invoices/Invoice/InvoiceRowView.swift
+++ b/Invoice Maker/Views/Invoices/Invoice/InvoiceRowView.swift
@@ -19,7 +19,7 @@ struct InvoiceRowView: View {
 
                 Spacer()
 
-                Text(invoice.totalWithVAT, format: .currencyFormatter(code: invoice.currency ?? Currency.IRR))
+                Text(invoice.totalWithDiscount, format: .currencyFormatter(code: invoice.currency ?? Currency.IRR))
                     .font(.subheadline)
                     .foregroundColor(.secondary)
                     .lineLimit(1)

--- a/Invoice Maker/Views/Invoices/InvoicesView.swift
+++ b/Invoice Maker/Views/Invoices/InvoicesView.swift
@@ -37,7 +37,7 @@ struct InvoicesView: View {
 
                                     Spacer()
 
-                                    Text(invoice.totalWithVAT, format: .currencyFormatter(code: invoice.currency ?? Currency.IRR))
+                                    Text(invoice.totalWithDiscount, format: .currencyFormatter(code: invoice.currency ?? Currency.IRR))
                                         .font(.subheadline)
                                         .foregroundColor(.secondary)
                                         .lineLimit(1)
@@ -79,7 +79,7 @@ struct InvoicesView: View {
 
                                 Spacer()
 
-                                Text(invoice.totalWithVAT, format: .currencyFormatter(code: invoice.currency ?? Currency.IRR))
+                                Text(invoice.totalWithDiscount, format: .currencyFormatter(code: invoice.currency ?? Currency.IRR))
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)
                                     .lineLimit(1)


### PR DESCRIPTION
This pull request updates the invoice calculation logic to ensure that discounts are applied after VAT, rather than before, and updates the UI and PDF output accordingly. It also makes minor improvements to currency formatting and UI labels.

Key changes:

**Invoice Calculation Logic:**

- Refactored the `SchemaV1.Invoice` computed properties so that VAT is calculated before discount, and the final total (`totalWithDiscount`) reflects this new order. This changes the calculation flow to: total → add VAT → subtract discount.

**UI and Display Updates:**

- Updated all invoice summary displays (`InvoiceRowView`, `InvoicesView`, `InvoiceMainDetailsView`) to show `totalWithDiscount` as the final amount instead of `totalWithVAT`, ensuring consistency with the new calculation logic. [[1]](diffhunk://#diff-5e6bbbfcf820cc365eec2651c4387088412c5dddc5681dc4734e77abb6d8df93L22-R22) [[2]](diffhunk://#diff-46562d88f23dd872eb5894b2d9306442bb22012204c275d7faed792ac211fb55L40-R40) [[3]](diffhunk://#diff-46562d88f23dd872eb5894b2d9306442bb22012204c275d7faed792ac211fb55L82-R82) [[4]](diffhunk://#diff-558349a5a50bf3d582debb7aa6dae50548f7387faa59555116471fe07d1ed456L29-R31)
- Adjusted the order of fields in `InvoiceFormView` so that VAT is entered before discount, matching the new calculation order.

**PDF Output:**

- Changed the PDF invoice table to list VAT before discount, and updated the final amount row to use `totalWithDiscount`, reflecting the new calculation order and labels.

**Currency Formatting:**

- Improved the `CurrencyFormatStyle` to handle decimal places and separators more consistently, and to properly label IRR and Toman values.

**Minor UI Improvements:**

- Changed the label on the contacts permission alert button from "ادامه" ("Continue") to "بازگشت" ("Back") for better clarity.
- Updated the app version from 1.41.2 to 1.41.3 in the project file. [[1]](diffhunk://#diff-8970c4e501c1dcbcbb9b8a2bb5b7a9bf3b65c740bac79b13d6e7eed18ff7caf0L848-R848) [[2]](diffhunk://#diff-8970c4e501c1dcbcbb9b8a2bb5b7a9bf3b65c740bac79b13d6e7eed18ff7caf0L887-R887)